### PR TITLE
Fixed double quota mark

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -64,7 +64,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\\n"
 "X-Generator: Poedit 3.4.2\\n"
 `
-					po_obj[key] += `\nmsgid "${obj[keys]}"\nmsgstr "${multiline ? obj[key].replaceAll("\\n", '\\n"\n"') : obj[key]}"\n`;
+					po_obj[key] += `\nmsgid "${obj[keys]}"\nmsgstr "${multiline ? obj[key].replaceAll("\"","\\\"").replaceAll("\\n", '\\n"\n"') : obj[key].replaceAll("\"","\\\"")}"\n`;
 				}
 			}
 		}


### PR DESCRIPTION
Fixed that if string contains double quota marks, it won't add backslash before the double quota mark